### PR TITLE
Jvictor/slate refactor

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-datacap.md
+++ b/.github/ISSUE_TEMPLATE/request-datacap.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ##  Basic Information
 
-Please fill in the following basic information about yourself
+Please fill in the following basic information about yourself.
 
 **Name / Organization / Alias**: 
 
@@ -24,15 +24,14 @@ Please fill in the following basic information about yourself
 **Intended Use Case / Allocation Plan**:
 
 **Contact Information**: 
- 
+
+**Links to prior approvals:
  
 ## Additional Information 
 
 You can also provide us more information you think could be relevant for us to check your identity or your use case.  
 
-
 ###### _Note: If you are not familiar with markdown language, use the Preview tab to make sure the tables are properly filled_
-
 
 ### Disclaimer
 

--- a/.github/ISSUE_TEMPLATE/request-datacap.md
+++ b/.github/ISSUE_TEMPLATE/request-datacap.md
@@ -7,30 +7,6 @@ assignees: ''
 
 ---
 
-## Use
-
-### How it works?
-
-Creating a new issue you are requesting to be a verified client for Filecoin and assign datacap to your address.  As verified client you could get better deals from miners as you will be considered trustable. For now we won’t assign more datacap for an already verified client, so if you consume all datacap you must start the process again with a different address
-
-### Why do I need to provide so much information?
-
-We need to check your identity and the purpose of your request. The more datacap you are requesting the more info we need.
-
-### Can you explain to me the steps of this process?
-
-First you have to create a new issue filling the info. You can also include additional information you think could be useful for us. But be aware that this issue will be public so don’t include sensitive information 
-
-You will need to have a GitHub user to open an issue. The activity of your GitHub account also will help us to get an idea of who you are.
-
-This new issue will be assigned to a verifier, who will check the info you provided us. If your are requesting a big figure of datacap, or the info you provided is not clear enough, the verifier could ask you to provide additional information.
-
-The verifier will comment on the issue to ask for this info. You will be notified on the email address associated with your GitHub address.
-
-Once the verifier can check that you are a trusted person or company, he/she will assign you the requested datacap. The verifier will provide you a way to check the status of your data cap’s allocation   
-
-
-
 ##  Basic Information
 
 Please fill in the following basic information about yourself

--- a/.github/ISSUE_TEMPLATE/request-datacap.md
+++ b/.github/ISSUE_TEMPLATE/request-datacap.md
@@ -31,7 +31,7 @@ Please fill in the following basic information about yourself
 You can also provide us more information you think could be relevant for us to check your identity or your use case.  
 
 
-###### _Note: If you are not familiarice with markdown language, use the Preview tab to make sure the tables are properly filled_
+###### _Note: If you are not familiar with markdown language, use the Preview tab to make sure the tables are properly filled_
 
 
 ### Disclaimer

--- a/.github/ISSUE_TEMPLATE/request-datacap.md
+++ b/.github/ISSUE_TEMPLATE/request-datacap.md
@@ -11,34 +11,24 @@ assignees: ''
 
 Please fill in the following basic information about yourself
 
-| Information                       | Value  |
-| ------------------------| ------------------------ |
-| Name / Organization / Alias             |             |                          
-| Public Profile (LinkedIn/Website/Other Proof)                   |             |                                
-| Data Cap Requested (Total Amount in GB)    |             |                                
-| Client Address     |             |       
+**Name / Organization / Alias**: 
 
+**Public Profile (LinkedIn/Website/Other Proof)**: 
+
+**Data Cap Requested (Total Amount in GB)**:   
 
 ## Optional Information 
   
-The  next information is optional but it will help us to know you better and trust you with datacap
+**Client Address(es)**:
 
-| Information                       | Value  |
-| ------------------------| ------------------------ |                   
-| Contact information           |                  |              
-|  Intended Use Case / Allocation Plan               |             |            
+**Intended Use Case / Allocation Plan**:
 
+**Contact Information**: 
  
  
 ## Additional Information 
 
-You can also provide us more information you think could be relevant for us to check your identity or your use case 
-
-| Information                       | Value  |
-| ------------------------| ------------------------ |    
-|             |             | 
-|             |             | 
-
+You can also provide us more information you think could be relevant for us to check your identity or your use case.  
 
 
 ###### _Note: If you are not familiarice with markdown language, use the Preview tab to make sure the tables are properly filled_

--- a/.github/ISSUE_TEMPLATE/request-datacap.md
+++ b/.github/ISSUE_TEMPLATE/request-datacap.md
@@ -25,7 +25,7 @@ Please fill in the following basic information about yourself.
 
 **Contact Information**: 
 
-**Links to prior approvals:
+**Links to prior approvals**:
  
 ## Additional Information 
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# TestFlows
-Test offchain flows
+## TestFlows Use
+
+### How it works?
+
+Creating a new issue you are requesting to be a verified client for Filecoin and assign datacap to your address.  As verified client you could get better deals from miners as you will be considered trustable. For now we won’t assign more datacap for an already verified client, so if you consume all datacap you must start the process again with a different address
+
+### Why do I need to provide so much information?
+
+We need to check your identity and the purpose of your request. The more datacap you are requesting the more info we need.
+
+### Can you explain to me the steps of this process?
+
+First you have to create a new issue filling the info. You can also include additional information you think could be useful for us. But be aware that this issue will be public so don’t include sensitive information 
+
+You will need to have a GitHub user to open an issue. The activity of your GitHub account also will help us to get an idea of who you are.
+
+This new issue will be assigned to a verifier, who will check the info you provided us. If your are requesting a big figure of datacap, or the info you provided is not clear enough, the verifier could ask you to provide additional information.
+
+The verifier will comment on the issue to ask for this info. You will be notified on the email address associated with your GitHub address.
+
+Once the verifier can check that you are a trusted person or company, he/she will assign you the requested datacap. The verifier will provide you a way to check the status of your data cap’s allocation   


### PR DESCRIPTION
What do you think about this? My general sense is that we try and strip down what we ask (and we figure out how we add back in more things as we need). 

Thinking through something like the slate example, it made me realize that we might have more edge cases than we think (i.e. a developer may want to have several addresses verified). 

Reason you might want more than one: 
- Riba is developing locally.
- I am developing locally. 
- Both of us need to be able to test verified deals -> unless we share private keys/seedphrases we can't spend from teh same account. 